### PR TITLE
List menu system and command aliases

### DIFF
--- a/Lkhsoft.Dring.Server/Cli/CommandParser.cs
+++ b/Lkhsoft.Dring.Server/Cli/CommandParser.cs
@@ -25,10 +25,23 @@ public class CommandParser
     {
         DefaultContainer.ComposeParts(this);
 
-        _commands = (_commandImports ?? throw new InvalidOperationException("CLI commands import failed")).ToDictionary(
-            import => import.Metadata.CommandName,
-            import => import.Value
-        );
+        _commands = (_commandImports ?? throw new InvalidOperationException("CLI commands import failed"))
+            .SelectMany(import =>
+            {
+                var commands = new List<KeyValuePair<string, ICommand>>
+                {
+                    new KeyValuePair<string, ICommand>(import.Metadata.CommandName, import.Value)
+                };
+
+                // Si Alias n'est pas null ou vide, ajouter l'alias également
+                if (!String.IsNullOrEmpty(import.Metadata.CommandAlias))
+                {
+                    commands.Add(new KeyValuePair<string, ICommand>(import.Metadata.CommandAlias, import.Value));
+                }
+
+                return commands;
+            })
+            .ToDictionary(command => command.Key, command => command.Value);
     }
 
     /// <summary>

--- a/Lkhsoft.Dring.Server/Cli/Commands/Authentication/AddUserCommand.cs
+++ b/Lkhsoft.Dring.Server/Cli/Commands/Authentication/AddUserCommand.cs
@@ -10,6 +10,7 @@ namespace Lkhsoft.Dring.Server.Cli.Commands.Authentication;
 /// </summary>
 [Export(typeof(ICommand))]
 [ExportMetadata("CommandName", "ADDUSER")]
+[ExportMetadata("CommandAlias", "")]
 public class AddUserCommand : AuthenticationCommandBase
 {
     /// <inheritdoc />

--- a/Lkhsoft.Dring.Server/Cli/Commands/Authentication/AddUserCommand.cs
+++ b/Lkhsoft.Dring.Server/Cli/Commands/Authentication/AddUserCommand.cs
@@ -20,8 +20,8 @@ public class AddUserCommand : AuthenticationCommandBase
             Console.WriteLine("Usage: ADDUSER <username>");
             return;
         }
-
-
+        
+        
         var username = args[0];
         if (await UserExistsAsync(username))
         {
@@ -29,7 +29,7 @@ public class AddUserCommand : AuthenticationCommandBase
             _logger.LogWarning($"USERADD command failed. User {username} already exists in the database.");
             return;
         }
-
+        
         string? password;
         var iv = GetRandomIv();
         try
@@ -55,7 +55,7 @@ public class AddUserCommand : AuthenticationCommandBase
             _logger.LogError(message);
         }
     }
-
+    
     /// <summary>
     /// Generate a random IV of 16 bytes length
     /// </summary>
@@ -67,7 +67,7 @@ public class AddUserCommand : AuthenticationCommandBase
         rng.GetBytes(iv);
         return BitConverter.ToString(iv).Replace("-", String.Empty);
     }
-
+    
     /// <summary>
     /// Create a new user in the database
     /// </summary>

--- a/Lkhsoft.Dring.Server/Cli/Commands/Authentication/AuthenticationCommandBase.cs
+++ b/Lkhsoft.Dring.Server/Cli/Commands/Authentication/AuthenticationCommandBase.cs
@@ -40,7 +40,7 @@ public abstract class AuthenticationCommandBase : CommandBase
 
         await command.ExecuteNonQueryAsync();
     }
-
+    
     /// <summary>
     /// Check if a user already exists in the database
     /// </summary>
@@ -58,7 +58,7 @@ public abstract class AuthenticationCommandBase : CommandBase
         await using var connection = new SQLiteConnection(ConnectionString);
         await connection.OpenAsync();
         await using var command = new SQLiteCommand(query, connection);
-
+        
         command.Parameters.AddWithValue("@Username", username);
 
         var result = await command.ExecuteScalarAsync();

--- a/Lkhsoft.Dring.Server/Cli/Commands/Authentication/DelUserCommand.cs
+++ b/Lkhsoft.Dring.Server/Cli/Commands/Authentication/DelUserCommand.cs
@@ -8,6 +8,7 @@ namespace Lkhsoft.Dring.Server.Cli.Commands.Authentication;
 /// </summary>
 [Export(typeof(ICommand))]
 [ExportMetadata("CommandName", "DELUSER")]
+[ExportMetadata("CommandAlias", "")]
 public class DelUserCommand : AuthenticationCommandBase
 {
     /// <inheritdoc />

--- a/Lkhsoft.Dring.Server/Cli/Commands/Authentication/DelUserCommand.cs
+++ b/Lkhsoft.Dring.Server/Cli/Commands/Authentication/DelUserCommand.cs
@@ -18,7 +18,7 @@ public class DelUserCommand : AuthenticationCommandBase
             Console.WriteLine("Usage: DELUSER <username>");
             return;
         }
-
+        
         var username = args[0];
         if (!await UserExistsAsync(username))
         {
@@ -33,11 +33,11 @@ public class DelUserCommand : AuthenticationCommandBase
             _logger.LogError($"DELUSER command failed. User {username} could not be deleted");
             return;
         }
-
+        
         Console.WriteLine("DELUSER command executed. User deleted successfully");
         _logger.LogInfo($"User {username} deleted at {DateTime.Now}");
     }
-
+    
     /// <summary>
     /// Removes a user from the database
     /// </summary>

--- a/Lkhsoft.Dring.Server/Cli/Commands/Authentication/LogoffCommand.cs
+++ b/Lkhsoft.Dring.Server/Cli/Commands/Authentication/LogoffCommand.cs
@@ -8,6 +8,7 @@ namespace Lkhsoft.Dring.Server.Cli.Commands.Authentication;
 /// </summary>
 [Export(typeof(ICommand))]
 [ExportMetadata("CommandName", "LOGOFF")]
+[ExportMetadata("CommandAlias", "LOGOUT")]
 public class LogoffCommand : AuthenticationCommandBase
 {
     private readonly string _connectionString = "Data Source=users.db;Version=3;";

--- a/Lkhsoft.Dring.Server/Cli/Commands/Authentication/LogonCommand.cs
+++ b/Lkhsoft.Dring.Server/Cli/Commands/Authentication/LogonCommand.cs
@@ -41,7 +41,8 @@ public class LogonCommand : AuthenticationCommandBase
         {
             return;
         }
-
+        
+        
 
         if (await AuthenticateUserAsync(username, password))
         {
@@ -84,7 +85,7 @@ public class LogonCommand : AuthenticationCommandBase
         return Convert.ToInt32(result) > 0;
     }
 
-
+   
     /// <summary>
     /// Add the newly created session to the database
     /// </summary>
@@ -102,7 +103,7 @@ public class LogonCommand : AuthenticationCommandBase
 
         await command.ExecuteNonQueryAsync();
     }
-
+    
     /// <summary>
     /// Get user initialization vector
     /// </summary>

--- a/Lkhsoft.Dring.Server/Cli/Commands/Authentication/LogonCommand.cs
+++ b/Lkhsoft.Dring.Server/Cli/Commands/Authentication/LogonCommand.cs
@@ -12,6 +12,7 @@ namespace Lkhsoft.Dring.Server.Cli.Commands.Authentication;
 /// </summary>
 [Export(typeof(ICommand))]
 [ExportMetadata("CommandName", "LOGON")]
+[ExportMetadata("CommandAlias", "SU")]
 public class LogonCommand : AuthenticationCommandBase
 {
     /// <summary>

--- a/Lkhsoft.Dring.Server/Cli/Commands/ClearCommand.cs
+++ b/Lkhsoft.Dring.Server/Cli/Commands/ClearCommand.cs
@@ -3,17 +3,16 @@ using System.ComponentModel.Composition;
 namespace Lkhsoft.Dring.Server.Cli.Commands;
 
 /// <summary>
-///     EXIT command implementation
+///     CLEAR command implementation
 /// </summary>
 [Export(typeof(ICommand))]
-[ExportMetadata("CommandName", "EXIT")]
-[ExportMetadata("CommandAlias", "QUIT")]
-public class ExitCommand : CommandBase
+[ExportMetadata("CommandName", "CLEAR")]
+[ExportMetadata("CommandAlias", "")]
+public class ClearCommand : CommandBase
 {
     /// <inheritdoc />
     public override void Execute(params string[] args)
     {
-        Console.WriteLine("Exiting...");
-        Environment.Exit(0);
+        Console.Clear();
     }
 }

--- a/Lkhsoft.Dring.Server/Cli/Commands/CommandBase.cs
+++ b/Lkhsoft.Dring.Server/Cli/Commands/CommandBase.cs
@@ -34,14 +34,14 @@ public abstract class CommandBase : ICommand
 
         return input;
     }
-
+    
     /// <summary>
     /// Reads a secure line from the console
     /// </summary>
     /// <param name="iv">Initialization vector</param>
     /// <returns></returns>
     /// <exception cref="OperationCanceledException">Command has been canceled</exception>
-    protected string ReadSecureOptions(string iv)
+    protected string ReadSecureOptions(string iv )
     {
         var input = ConsoleEventHandler.ReadAndEncryptSecureLine(iv);
         if (input == null)

--- a/Lkhsoft.Dring.Server/Cli/Commands/HelpCommand.cs
+++ b/Lkhsoft.Dring.Server/Cli/Commands/HelpCommand.cs
@@ -9,6 +9,7 @@ namespace Lkhsoft.Dring.Server.Cli.Commands;
 /// </summary>
 [Export(typeof(ICommand))]
 [ExportMetadata("CommandName", "HELP")]
+[ExportMetadata("CommandAlias", "?")]
 public class HelpCommand : CommandBase
 {
     /// <summary>

--- a/Lkhsoft.Dring.Server/Cli/Commands/HelpCommand.cs
+++ b/Lkhsoft.Dring.Server/Cli/Commands/HelpCommand.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.Composition;
 using System.Globalization;
+using Lkhsoft.Dring.Server.Utility;
 
 namespace Lkhsoft.Dring.Server.Cli.Commands;
 
@@ -10,6 +11,11 @@ namespace Lkhsoft.Dring.Server.Cli.Commands;
 [ExportMetadata("CommandName", "HELP")]
 public class HelpCommand : CommandBase
 {
+    /// <summary>
+    /// Enumeration of all commands
+    /// </summary>
+    [ImportMany] private IEnumerable<Lazy<ICommand, ICommandMetadata>> _commandImports;
+    
     /// <inheritdoc />
     public override void Execute(params string[] args)
     {
@@ -21,7 +27,7 @@ public class HelpCommand : CommandBase
 
         if (args.Length == 0)
         {
-            Console.WriteLine("Usage: HELP <command>");
+            ConsoleEventHandler.DisplayItems("HELP", _commandImports.Select(x => x.Metadata.CommandName));
             return;
         }
 

--- a/Lkhsoft.Dring.Server/Cli/Commands/ISPFCommand.cs
+++ b/Lkhsoft.Dring.Server/Cli/Commands/ISPFCommand.cs
@@ -9,6 +9,7 @@ namespace Lkhsoft.Dring.Server.Cli.Commands;
 /// </summary>
 [Export(typeof(ICommand))]
 [ExportMetadata("CommandName", "ISPF")]
+[ExportMetadata("CommandAlias", "")]
 public class ISPFCommand : CommandBase
 {
     /// <summary>

--- a/Lkhsoft.Dring.Server/Cli/Commands/ISPFCommand.cs
+++ b/Lkhsoft.Dring.Server/Cli/Commands/ISPFCommand.cs
@@ -16,7 +16,7 @@ public class ISPFCommand : CommandBase
     /// </summary>
     [Import]
     private BatchConfigLoader BatchConfigLoader { get; set; }
-
+    
     /// <inheritdoc />
     public override void Execute(params string[] args)
     {
@@ -33,7 +33,7 @@ public class ISPFCommand : CommandBase
 
 
         ShowMainMenuOptions();
-
+        
         while (!exitMenu)
             try
             {
@@ -85,12 +85,12 @@ public class ISPFCommand : CommandBase
                 break;
             }
     }
-
+    
     #region BATCH
-
     /// <summary>
     /// Displays the main menu options
     /// </summary>
+
     private void ShowMainMenuOptions()
     {
         Console.WriteLine("=========================");
@@ -113,7 +113,7 @@ public class ISPFCommand : CommandBase
     private void ShowBatchMenu()
     {
         var exitBatchMenu = false;
-
+        
         Console.WriteLine();
         Console.WriteLine("===========");
         Console.WriteLine("Batch Menu");
@@ -138,7 +138,7 @@ public class ISPFCommand : CommandBase
             {
                 break;
             }
-
+            
             if (UInt16.TryParse(input, out var batchIndex) && batchIndex > 0 && batchIndex <= batchList.Count)
             {
                 var selectedBatch = batchList[batchIndex - 1];
@@ -172,7 +172,6 @@ public class ISPFCommand : CommandBase
             {
                 break;
             }
-
             // Si l'utilisateur entre une valeur, l'utiliser, sinon garder la valeur par défaut
             var finalValue = String.IsNullOrWhiteSpace(userInput) ? param.DefaultValue : userInput;
             Console.WriteLine($"{param.Name} set to: {finalValue}");
@@ -198,7 +197,7 @@ public class ISPFCommand : CommandBase
         _ = UInt16.TryParse(defaultScheduledTime, out var defaultLaunchTime);
         var batchSchedule = new Dictionary<string, DateTime>
         {
-            {batch.Name, DateTime.Now.AddMinutes(defaultLaunchTime)}
+            { batch.Name, DateTime.Now.AddMinutes(defaultLaunchTime) }
         };
 
         // Charger la configuration des batchs
@@ -207,11 +206,13 @@ public class ISPFCommand : CommandBase
         var batchExecutorPool = new BatchExecutorPool(BatchConfigLoader.BatchConfig.Batches, batchSchedule);
 
         // S'abonner à l'observable pour afficher les messages dans la console
-        batchExecutorPool.CompletionObservable.Subscribe(message => { _logger.LogDebug(message); });
-
+        batchExecutorPool.CompletionObservable.Subscribe(message =>
+        {
+            _logger.LogDebug(message);
+        });
+        
         // Attendre que tous les batchs soient exécutés
         await batchExecutorPool.WaitForCompletionAsync();
     }
-
     #endregion
 }

--- a/Lkhsoft.Dring.Server/Cli/ICommandMetadata.cs
+++ b/Lkhsoft.Dring.Server/Cli/ICommandMetadata.cs
@@ -9,4 +9,9 @@ public interface ICommandMetadata
     ///     Command name
     /// </summary>
     string CommandName { get; }
+    
+    /// <summary>
+    ///     Command alias
+    /// </summary>
+    string CommandAlias { get; }
 }

--- a/Lkhsoft.Dring.Server/Lkhsoft.Dring.Server.csproj
+++ b/Lkhsoft.Dring.Server/Lkhsoft.Dring.Server.csproj
@@ -24,7 +24,7 @@
         <PackageReference Include="System.Composition" Version="9.0.0"/>
         <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.0"/>
         <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119"/>
-        <PackageReference Include="System.Reactive" Version="6.0.1"/>
+        <PackageReference Include="System.Reactive" Version="6.0.1" />
         <PackageReference Include="YamlDotNet" Version="16.3.0"/>
     </ItemGroup>
 
@@ -33,18 +33,18 @@
         <EmbeddedResource Include="nlog.config.yaml">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </EmbeddedResource>
-        <None Remove="database.sql"/>
+        <None Remove="database.sql" />
         <EmbeddedResource Include="database.sql">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </EmbeddedResource>
-        <None Remove="batch.yaml"/>
-        <None Remove="Scripts\write_timespan.lua"/>
+        <None Remove="batch.yaml" />
+        <None Remove="Scripts\write_timespan.lua" />
         <EmbeddedResource Include="Scripts\write_timespan.lua">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </EmbeddedResource>
-        <None Remove="batch.config.yaml"/>
+        <None Remove="batch.config.yaml" />
         <EmbeddedResource Include="batch.config.yaml">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </EmbeddedResource>
     </ItemGroup>
 

--- a/Lkhsoft.Dring.Server/Lua/Batch/BatchConfig.cs
+++ b/Lkhsoft.Dring.Server/Lua/Batch/BatchConfig.cs
@@ -9,7 +9,7 @@ public class BatchConfig
     /// Scripts folder path
     /// </summary>
     public string Path { get; set; }
-
+    
     /// <summary>
     /// Registered batch scripts
     /// </summary>

--- a/Lkhsoft.Dring.Server/Lua/Batch/BatchConfigLoader.cs
+++ b/Lkhsoft.Dring.Server/Lua/Batch/BatchConfigLoader.cs
@@ -16,35 +16,32 @@ public class BatchConfigLoader
     /// Loaded configuration
     /// </summary>
     public readonly BatchConfig BatchConfig;
-
+    
     /// <summary>
     /// Default constructor
     /// </summary>
     public BatchConfigLoader()
     {
         BatchConfig = LoadBatchConfig().BatchConfig;
-        if (!String.IsNullOrEmpty(BatchConfig.Path) &&
-            (BatchConfig.Path.EndsWith('/') || BatchConfig.Path.EndsWith('\\')))
+        if (!String.IsNullOrEmpty(BatchConfig.Path) && (BatchConfig.Path.EndsWith('/') || BatchConfig.Path.EndsWith('\\')))
         {
-            BatchConfig.Path = BatchConfig.Path.Substring(0, BatchConfig.Path.Length - 1);
+            BatchConfig.Path =  BatchConfig.Path.Substring(0, BatchConfig.Path.Length - 1);
         }
     }
-
+    
     /// <summary>
     /// Load the batch configuration from the specified file
     /// </summary>
     /// <returns>The deserialized batch script configuration</returns>
     private static YamlConfiguration LoadBatchConfig()
     {
-        var filePath = ConfigurationManager.AppSettings["BatchConfigPath"] ??
-                       throw new InvalidOperationException(
-                           "Batch configuration file path not found in the configuration file");
-        var deserializer = new DeserializerBuilder().WithNamingConvention(CamelCaseNamingConvention.Instance)
+        var filePath = ConfigurationManager.AppSettings["BatchConfigPath"] ?? throw new InvalidOperationException("Batch configuration file path not found in the configuration file");
+        var deserializer = new DeserializerBuilder() .WithNamingConvention(CamelCaseNamingConvention.Instance)
             .Build();
         using var reader = new StreamReader(filePath);
         return deserializer.Deserialize<YamlConfiguration>(reader);
     }
-
+    
     /// <summary>
     /// Yaml model of the batch configuration
     /// </summary>

--- a/Lkhsoft.Dring.Server/Lua/Batch/BatchExecutor.cs
+++ b/Lkhsoft.Dring.Server/Lua/Batch/BatchExecutor.cs
@@ -15,7 +15,7 @@ public class BatchExecutor
     /// Batch scripts to be executed
     /// </summary>
     private IEnumerable<BatchScript> _batchScripts;
-
+    
     /// <summary>
     /// Scheduled batch execution times
     /// </summary>
@@ -53,14 +53,16 @@ public class BatchExecutor
     /// </summary>
     /// <param name="batchScript">Batch script to be executed</param>
     /// <param name="scheduledTime">Execution date time</param>
-    private void ScheduleBatchExecution(BatchScript batchScript, DateTime scheduledTime,
-        Subject<string> completionSubject)
+    private void ScheduleBatchExecution(BatchScript batchScript, DateTime scheduledTime, Subject<string> completionSubject)
     {
         var delay = scheduledTime - DateTime.Now;
         if (delay > TimeSpan.Zero)
         {
             // Si l'exécution doit être différée, planifier une tâche après le délai
-            Task.Delay(delay).ContinueWith(_ => { ExecuteLuaScript(batchScript, completionSubject); });
+            Task.Delay(delay).ContinueWith(_ =>
+            {
+                ExecuteLuaScript(batchScript, completionSubject);
+            });
         }
         else
         {
@@ -77,7 +79,7 @@ public class BatchExecutor
     {
         var configLoader = DefaultContainer.Get<BatchConfigLoader>();
         var luaScriptPath = String.Empty;
-
+        
         if (OperatingSystem.IsWindows())
         {
             luaScriptPath = String.Format(CultureInfo.CurrentCulture, "{0}\\{1}", configLoader?.BatchConfig.Path,
@@ -96,20 +98,19 @@ public class BatchExecutor
 
         if (String.IsNullOrWhiteSpace(luaScriptPath) || !File.Exists(luaScriptPath))
         {
-            Console.WriteLine($"Lua script {script} not found");
+            Console.WriteLine($"Lua script { script } not found");
             return;
         }
-
         var luaScript = File.ReadAllText(luaScriptPath);
 
         try
         {
             using var lua = new NLua.Lua();
-
+            
             lua.NewTable("arg");
 
             var outputAllowedConfig = ConfigurationManager.AppSettings["BatchOutputAllowed"] ?? "False";
-
+            
             _ = Boolean.TryParse(outputAllowedConfig, out var outputAllowed);
 
             if (!outputAllowed)
@@ -117,12 +118,12 @@ public class BatchExecutor
                 // Ne pas afficher la sortie standard de lua pour les batches
                 lua.DoString("print = function() end");
             }
-
-            for (byte i = 0; i < script.Parameters.Count(); i++)
+           
+            for(byte i = 0; i < script.Parameters.Count(); i++)
             {
                 lua[$"arg[{i}]"] = script.Parameters.ElementAt(i).DefaultValue;
             }
-
+           
             lua.DoString(luaScript);
             completionSubject.OnNext($"Lua script {script} executed successfully.");
         }

--- a/Lkhsoft.Dring.Server/Lua/Batch/BatchExecutorPool.cs
+++ b/Lkhsoft.Dring.Server/Lua/Batch/BatchExecutorPool.cs
@@ -13,12 +13,12 @@ public class BatchExecutorPool
     /// Maximum number of batch scripts per task
     /// </summary>
     private const int MaxBatchsPerTask = 5;
-
+    
     /// <summary>
     /// Running tasks that contain batch scripts
     /// </summary>
     private List<Task> _tasks = new List<Task>();
-
+    
     /// <summary>
     /// Completion subject
     /// </summary>
@@ -38,7 +38,7 @@ public class BatchExecutorPool
     {
         // Regrouper les batchs en groupes de taille maximale
         var batchGroups = batchScripts
-            .Select((batch, index) => new {batch, index})
+            .Select((batch, index) => new { batch, index })
             .GroupBy(x => x.index / MaxBatchsPerTask)
             .Select(group => group.Select(x => x.batch).ToList())
             .ToList();

--- a/Lkhsoft.Dring.Server/Lua/Batch/BatchParameter.cs
+++ b/Lkhsoft.Dring.Server/Lua/Batch/BatchParameter.cs
@@ -9,12 +9,12 @@ public class BatchParameter
     /// Parameter name
     /// </summary>
     public string Name { get; set; }
-
+    
     /// <summary>
     /// Parameter type
     /// </summary>
     public string Type { get; set; }
-
+    
     /// <summary>
     /// Parameter default value
     /// </summary>

--- a/Lkhsoft.Dring.Server/Lua/Batch/BatchScript.cs
+++ b/Lkhsoft.Dring.Server/Lua/Batch/BatchScript.cs
@@ -9,17 +9,17 @@ public class BatchScript
     /// Script name
     /// </summary>
     public string Name { get; set; }
-
+    
     /// <summary>
     /// Script file path
     /// </summary>
     public string Script { get; set; }
-
+    
     /// <summary>
     /// Script description
     /// </summary>
     public string Description { get; set; }
-
+    
     /// <summary>
     /// Script parameters
     /// </summary>

--- a/Lkhsoft.Dring.Server/Program.cs
+++ b/Lkhsoft.Dring.Server/Program.cs
@@ -93,9 +93,8 @@ internal class Program
         await _semaphore.WaitAsync();
         _semaphore.Release();
         Console.WriteLine("CLI Ready. Type 'exit' to quit.");
-        _logger.LogInfo($"Server started on ports TCP:{TcpPort} and UDP:{UdpPort}");
-        ;
-
+        _logger.LogInfo($"Server started on ports TCP:{TcpPort} and UDP:{UdpPort}");;
+        
         var commandParser = new CommandParser();
         ConsoleEventHandler.SetupConsoleEventHandlers();
 

--- a/Lkhsoft.Dring.Server/Utility/ConsoleEventHandler.cs
+++ b/Lkhsoft.Dring.Server/Utility/ConsoleEventHandler.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Security.Cryptography;
@@ -14,28 +15,28 @@ public class ConsoleEventHandler
     ///     Is exit requested ?
     /// </summary>
     private static bool _exitRequested;
-
+    
     /// <summary>
     /// Commands history
     /// </summary>
     private static LinkedList<string> _history = new LinkedList<string>();
-
+    
     /// <summary>
     /// Current history index
     /// </summary>
     private static LinkedListNode<string> _currentHistoryNode = null;
-
+    
     /// <summary>
     /// Map of AES keys by version number
     /// </summary>
     private static readonly Dictionary<int, byte[]> KeyVersions = new Dictionary<int, byte[]>
     {
-        {1, Convert.FromBase64String("9WpFqL8J7g5dYq8B5jK9nl6jPjdMN1FobNfhz0axdkM=")},
-        {2, Convert.FromBase64String("tDF3v6G3PqNbIh7D8HSTGpN9oYfrXfH76nboydHpCeY=")}
+        { 1, Convert.FromBase64String("9WpFqL8J7g5dYq8B5jK9nl6jPjdMN1FobNfhz0axdkM=") },
+        { 2, Convert.FromBase64String("tDF3v6G3PqNbIh7D8HSTGpN9oYfrXfH76nboydHpCeY=") }
     };
-
+    
     private static readonly byte[] FixedIV = Encoding.UTF8.GetBytes("0123456789abcdef");
-
+    
     /// <summary>
     /// Current key version
     /// </summary>
@@ -51,10 +52,10 @@ public class ConsoleEventHandler
     }
 
 
-    /// <summary>
-    /// Read a line from the console with command history support.
-    /// </summary>
-    public static string ReadLine()
+        /// <summary>
+        /// Read a line from the console with command history support.
+        /// </summary>
+        public static string ReadLine()
     {
         var input = string.Empty;
         _currentHistoryNode = null; // Réinitialise la position dans l'historique
@@ -144,7 +145,60 @@ public class ConsoleEventHandler
             Thread.Sleep(100);
         }
     }
+        
+    /// <summary>
+    /// Runs the file navigator
+    /// </summary>
+    /// <param name="items">Items to be displayed</param>
+    public static void DisplayItems(string caller, IEnumerable<string> items)
+    {
+        var currentIndex = 0;
 
+        while (true)
+        {
+            Console.Clear();
+            Console.WriteLine($"{caller} menu - Use arrows to navigate, 'q' to exit.");
+            DisplayMenu(items, currentIndex);
+
+            var key = Console.ReadKey(true).Key;
+            switch (key)
+            {
+                case ConsoleKey.UpArrow:
+                    if (currentIndex > 0) currentIndex--;
+                    break;
+                case ConsoleKey.DownArrow:
+                    if (currentIndex < items.Count() - 1) currentIndex++;
+                    break;
+                case ConsoleKey.Q:
+                    Console.Clear();
+                    return;
+                default:
+                    continue;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Navigate through the menu items
+    /// </summary>
+    /// <param name="items">Menu items</param>
+    /// <param name="selectedIndex">Current position in the menu</param>
+    private static void DisplayMenu(IEnumerable<string> items, int selectedIndex)
+    {
+        for (int i = 0; i < items.Count(); i++)
+        {
+            if (i == selectedIndex)
+            {
+                Console.ForegroundColor = ConsoleColor.Green; // Option sélectionnée
+                Console.WriteLine($"> {items.ElementAt(i)}");
+                Console.ResetColor();
+            }
+            else
+            {
+                Console.WriteLine($"  {items.ElementAt(i)}");
+            }
+        }
+    }
 
     /// <summary>
     /// Efface l'entrée actuelle de la console.
@@ -241,9 +295,7 @@ public class ConsoleEventHandler
         try
         {
             // Convertir le SecureString en texte clair temporairement
-            secureStringPointer =
-                Marshal.SecureStringToGlobalAllocUnicode(secureString ??
-                                                         throw new ArgumentNullException(nameof(secureString)));
+            secureStringPointer = Marshal.SecureStringToGlobalAllocUnicode(secureString ?? throw new ArgumentNullException(nameof(secureString)));
             var plainText = Marshal.PtrToStringUni(secureStringPointer);
 
             using var aes = Aes.Create();
@@ -253,7 +305,7 @@ public class ConsoleEventHandler
             aes.Padding = PaddingMode.PKCS7;
 
             using var memoryStream = new MemoryStream();
-            memoryStream.WriteByte((byte) version); // Écrit la version au début
+            memoryStream.WriteByte((byte)version); // Écrit la version au début
             memoryStream.Write(aes.IV, 0, aes.IV.Length); // Écrit l'IV
 
             using (var cryptoStream = new CryptoStream(memoryStream, aes.CreateEncryptor(), CryptoStreamMode.Write))

--- a/Lkhsoft.Dring.Server/database.sql
+++ b/Lkhsoft.Dring.Server/database.sql
@@ -2,43 +2,43 @@
 CREATE TABLE IF NOT EXISTS Users
 (
     Username
-        TEXT
-        PRIMARY
-            KEY,
+    TEXT
+    PRIMARY
+    KEY,
     Password
-        TEXT
-        NOT
-            NULL,
+    TEXT
+    NOT
+    NULL,
     IsConnected
-        INTEGER
-        NOT
-            NULL
-        DEFAULT
-            0,
+    INTEGER
+    NOT
+    NULL
+    DEFAULT
+    0,
     IV,
     TEXT
-        NOT
-            NULL
+    NOT 
+    NULL
 );
 
 -- Cretae the table Sessions if it does not exist
 CREATE TABLE IF NOT EXISTS Sessions
 (
     SessionId
-        TEXT
-        PRIMARY
-            KEY,
+    TEXT
+    PRIMARY
+    KEY,
     Username
-        TEXT
-        NOT
-            NULL,
+    TEXT
+    NOT
+    NULL,
     StartTime
-        TEXT
-        NOT
-            NULL,
+    TEXT
+    NOT
+    NULL,
     EndTime
-        TEXT,
+    TEXT,
     FOREIGN
-        KEY (Username)
-        REFERENCES Users (Username)
+    KEY (Username) 
+    REFERENCES Users (Username)
 );


### PR DESCRIPTION
This pull request includes several changes to the command-line interface (CLI) commands and their metadata in the `Lkhsoft.Dring.Server` project. The updates primarily focus on adding command aliases, improving the command parsing logic, and cleaning up the code.

### Enhancements to Command Parsing and Metadata:

* [`Lkhsoft.Dring.Server/Cli/CommandParser.cs`](diffhunk://#diff-4fa95fa4a79c9d0daf7526dd5ad10941b5a1eb8545a6995c9b4011bde2f2c27fL28-R44): Improved the command parsing logic to support command aliases by modifying the `_commands` dictionary initialization.
* [`Lkhsoft.Dring.Server/Cli/ICommandMetadata.cs`](diffhunk://#diff-ec3aba7116fc31b2c1efb2abf24b9143e593b6b148289665a3c2386ba9acb80aR12-R16): Added a new `CommandAlias` property to the `ICommandMetadata` interface.

### Addition of Command Aliases:

* [`Lkhsoft.Dring.Server/Cli/Commands/Authentication/LogoffCommand.cs`](diffhunk://#diff-5bad16671e14348f4d63b9c33d1e526f5bb21443d0b8b9b6d588e878afc05778R11): Added "LOGOUT" as an alias for the "LOGOFF" command.
* [`Lkhsoft.Dring.Server/Cli/Commands/Authentication/LogonCommand.cs`](diffhunk://#diff-146840b8c610171dea657e02151d95063068821ffddac2b22bb712cd842bbd75R15): Added "SU" as an alias for the "LOGON" command.
* [`Lkhsoft.Dring.Server/Cli/Commands/ExitCommand.cs`](diffhunk://#diff-2a12ea54f172b0a9f106e523b68e41fbd749593ae0d057785e3c750d34340570R10): Added "QUIT" as an alias for the "EXIT" command.
* [`Lkhsoft.Dring.Server/Cli/Commands/HelpCommand.cs`](diffhunk://#diff-361b7907553538542b77bf2a64bf3342dd2f94f515fe010a0809476488efc691R12-R19): Added "?" as an alias for the "HELP" command and imported `_commandImports` for displaying available commands. [[1]](diffhunk://#diff-361b7907553538542b77bf2a64bf3342dd2f94f515fe010a0809476488efc691R12-R19) [[2]](diffhunk://#diff-361b7907553538542b77bf2a64bf3342dd2f94f515fe010a0809476488efc691L24-R31)

### New Command Implementation:

* [`Lkhsoft.Dring.Server/Cli/Commands/ClearCommand.cs`](diffhunk://#diff-81e7dde4121278972bbc909589d665406ca1352192f07c6d98fe14bc6d3dee39R1-R18): Added a new `ClearCommand` class to implement the "CLEAR" command, which clears the console.

### Code Cleanup and Minor Fixes:

* [`Lkhsoft.Dring.Server/Lua/Batch/BatchConfigLoader.cs`](diffhunk://#diff-495d691510e1afb113dca3934d92f3fab3799ae3b9604c9fb2b2d81642567b2bL26-R26): Cleaned up the `BatchConfigLoader` constructor and `LoadBatchConfig` method for better readability. [[1]](diffhunk://#diff-495d691510e1afb113dca3934d92f3fab3799ae3b9604c9fb2b2d81642567b2bL26-R26) [[2]](diffhunk://#diff-495d691510e1afb113dca3934d92f3fab3799ae3b9604c9fb2b2d81642567b2bL39-R38)
* [`Lkhsoft.Dring.Server/Lua/Batch/BatchExecutor.cs`](diffhunk://#diff-7a5d493c906613cbdcfaf4de6fc9993b0fa9c666b83559b3cd04acafe738a70eL56-R65): Improved the `ScheduleBatchExecution` method by formatting the continuation task for better readability. [[1]](diffhunk://#diff-7a5d493c906613cbdcfaf4de6fc9993b0fa9c666b83559b3cd04acafe738a70eL56-R65) [[2]](diffhunk://#diff-7a5d493c906613cbdcfaf4de6fc9993b0fa9c666b83559b3cd04acafe738a70eL102)
* [`Lkhsoft.Dring.Server/Program.cs`](diffhunk://#diff-1bae2373fd08286c4e3a4221f811448b6fb46af99ad321aaca0ef931fe43ba9cL96-R96): Removed an unnecessary semicolon in the `Main` method.