### PR TITLE
Created triggers to set user online or disconnected

### DIFF
--- a/Lkhsoft.Dring.Server/Cli/Commands/Authentication/AuthenticationCommandBase.cs
+++ b/Lkhsoft.Dring.Server/Cli/Commands/Authentication/AuthenticationCommandBase.cs
@@ -24,24 +24,6 @@ public abstract class AuthenticationCommandBase : CommandBase
     }
 
     /// <summary>
-    ///     Update the status of the user's connection
-    /// </summary>
-    /// <param name="username">Username to update</param>
-    /// <param name="isConnected">User status</param>
-    private protected async Task UpdateUserConnectionStatusAsync(string username, bool isConnected)
-    {
-        await using var connection = new SQLiteConnection(ConnectionString);
-        await connection.OpenAsync();
-
-        var query = "UPDATE Users SET IsConnected = @IsConnected WHERE Username = @Username";
-        await using var command = new SQLiteCommand(query, connection);
-        command.Parameters.AddWithValue("@IsConnected", isConnected ? 1 : 0);
-        command.Parameters.AddWithValue("@Username", username);
-
-        await command.ExecuteNonQueryAsync();
-    }
-
-    /// <summary>
     /// Check if a user already exists in the database
     /// </summary>
     /// <param name="username">Username to check</param>

--- a/Lkhsoft.Dring.Server/Cli/Commands/Authentication/LogoffCommand.cs
+++ b/Lkhsoft.Dring.Server/Cli/Commands/Authentication/LogoffCommand.cs
@@ -39,8 +39,6 @@ public class LogoffCommand : AuthenticationCommandBase
             return;
         }
 
-        // Update the IsConnected field in the Users table
-        await UpdateUserConnectionStatusAsync(username, false);
         _logger.LogInfo($"User {username} logged off at {DateTime.Now}");
 
         // Mettre à jour la session en la retirant

--- a/Lkhsoft.Dring.Server/Cli/Commands/Authentication/LogonCommand.cs
+++ b/Lkhsoft.Dring.Server/Cli/Commands/Authentication/LogonCommand.cs
@@ -58,9 +58,7 @@ public class LogonCommand : AuthenticationCommandBase
 
             // Add session to the database
             _sessionService.AddSession(session);
-
-            // Update the IsConnected field in the Users table
-            await UpdateUserConnectionStatusAsync(username, true);
+            
             _logger.LogInfo($"User {username} logged on at {DateTime.Now}");
         }
         else

--- a/Lkhsoft.Dring.Server/database.sql
+++ b/Lkhsoft.Dring.Server/database.sql
@@ -46,3 +46,26 @@ CREATE TABLE IF NOT EXISTS Sessions
         KEY (Username)
         REFERENCES Users (Username)
 );
+
+-- Trigger that updates the IsConnected field of the Users table when a session is created
+CREATE TRIGGER IF NOT EXISTS UpdateUserOnSessionEnd
+    AFTER UPDATE OF EndTime
+    ON Sessions
+    FOR EACH ROW
+    WHEN NEW.EndTime IS NOT NULL
+BEGIN
+    UPDATE Users
+    SET IsConnected = 0
+    WHERE Username = NEW.Username;
+END;
+
+-- Trigger that updates the IsConnected field of the Users table when a session is created
+CREATE TRIGGER IF NOT EXISTS UpdateUserOnSessionStart
+    AFTER INSERT
+    ON Sessions
+    FOR EACH ROW
+BEGIN
+    UPDATE Users
+    SET IsConnected = 1
+    WHERE Username = NEW.Username;
+END;


### PR DESCRIPTION
This pull request focuses on refactoring the way user connection status is managed in the authentication commands by replacing inline code with database triggers. The most important changes include the removal of the `UpdateUserConnectionStatusAsync` method and the addition of triggers in the database to update the user connection status.

Changes to authentication commands:

* [`Lkhsoft.Dring.Server/Cli/Commands/Authentication/AuthenticationCommandBase.cs`](diffhunk://#diff-7a0b7f3b3da07d405da14f56eab771d6170a7f3428bd47aea0b63b3a874e1974L26-L43): Removed the `UpdateUserConnectionStatusAsync` method, which was responsible for updating the user's connection status in the database.
* [`Lkhsoft.Dring.Server/Cli/Commands/Authentication/LogoffCommand.cs`](diffhunk://#diff-5bad16671e14348f4d63b9c33d1e526f5bb21443d0b8b9b6d588e878afc05778L42-L43): Removed the call to `UpdateUserConnectionStatusAsync` when a user logs off.
* [`Lkhsoft.Dring.Server/Cli/Commands/Authentication/LogonCommand.cs`](diffhunk://#diff-146840b8c610171dea657e02151d95063068821ffddac2b22bb712cd842bbd75L62-L63): Removed the call to `UpdateUserConnectionStatusAsync` when a user logs on.

Changes to database schema:

* [`Lkhsoft.Dring.Server/database.sql`](diffhunk://#diff-bf7e86e4176a14bf5fcbede5eeaa41b1339b1269784afaacf74ead2b651c302eR49-R71): Added triggers `UpdateUserOnSessionEnd` and `UpdateUserOnSessionStart` to automatically update the `IsConnected` field in the `Users` table when a session ends or starts, respectively.